### PR TITLE
feat: add device button to mobile player

### DIFF
--- a/src/components/Layout/components/PlayingBar/DeviceButton.tsx
+++ b/src/components/Layout/components/PlayingBar/DeviceButton.tsx
@@ -1,0 +1,31 @@
+import { Tooltip } from '../../../Tooltip';
+import { useTranslation } from 'react-i18next';
+import { uiActions } from '../../../../store/slices/ui';
+import { useAppDispatch, useAppSelector } from '../../../../store/store';
+import { DeviceIcon, PhoneIcon } from '../../../Icons';
+
+const DeviceButton = () => {
+  const dispatch = useAppDispatch();
+  const { t } = useTranslation(['playingBar']);
+  const isDeviceOpen = useAppSelector((state) => !state.ui.devicesCollapsed);
+
+  const currentDevice = useAppSelector((state) => state.spotify.activeDeviceType);
+
+  return (
+    <Tooltip title={t('Connect to a device')}>
+      <button
+        onClick={() => dispatch(uiActions.toggleDevices())}
+        className={isDeviceOpen ? 'active-icon-button' : ''}
+        style={{ marginTop: 4, cursor: isDeviceOpen ? 'pointer' : 'not-allowed' }}
+      >
+        {currentDevice === 'Smartphone' ? (
+          <PhoneIcon active={isDeviceOpen} />
+        ) : (
+          <DeviceIcon active={isDeviceOpen} />
+        )}
+      </button>
+    </Tooltip>
+  );
+};
+
+export default DeviceButton;

--- a/src/components/Layout/components/PlayingBar/ExtraButtons.tsx
+++ b/src/components/Layout/components/PlayingBar/ExtraButtons.tsx
@@ -1,19 +1,13 @@
 // Components
 import { Col, Row } from 'antd';
 import VolumeControls from './Volume';
+import DeviceButton from './DeviceButton';
 import { Tooltip } from '../../../Tooltip';
 import { FullScreenPlayer } from '../../../FullScreen';
 import { FullScreen, useFullScreenHandle } from 'react-full-screen';
 
 // Icons
-import {
-  DetailsIcon,
-  DeviceIcon,
-  ExpandIcon,
-  ListIcon,
-  MicrophoneIcon,
-  PhoneIcon,
-} from '../../../Icons';
+import { DetailsIcon, ExpandIcon, ListIcon, MicrophoneIcon } from '../../../Icons';
 
 // I18n
 import { useTranslation } from 'react-i18next';
@@ -113,29 +107,6 @@ const ExpandButton = () => {
   );
 };
 
-const DeviceButton = () => {
-  const dispatch = useAppDispatch();
-  const { t } = useTranslation(['playingBar']);
-  const isDeviceOpen = useAppSelector((state) => !state.ui.devicesCollapsed);
-
-  const currentDevice = useAppSelector((state) => state.spotify.activeDeviceType);
-
-  return (
-    <Tooltip title={t('Connect to a device')}>
-      <button
-        onClick={() => dispatch(uiActions.toggleDevices())}
-        className={isDeviceOpen ? 'active-icon-button' : ''}
-        style={{ marginTop: 4, cursor: isDeviceOpen ? 'pointer' : 'not-allowed' }}
-      >
-        {currentDevice === 'Smartphone' ? (
-          <PhoneIcon active={isDeviceOpen} />
-        ) : (
-          <DeviceIcon active={isDeviceOpen} />
-        )}
-      </button>
-    </Tooltip>
-  );
-};
 
 const ExtraControlButtons = () => {
   return (

--- a/src/components/Layout/components/PlayingBar/mobilePlayer.tsx
+++ b/src/components/Layout/components/PlayingBar/mobilePlayer.tsx
@@ -2,6 +2,7 @@ import SongDetails from './SongDetails';
 import { useAppDispatch, useAppSelector } from '../../../../store/store';
 import { Col, Row } from 'antd';
 import { ListIcon, Pause, Play } from '../../../Icons';
+import DeviceButton from './DeviceButton';
 
 // Redux
 import { playerService } from '../../../../services/player';
@@ -67,29 +68,30 @@ const NowPlayingBarMobile = () => {
           <Col>
             <SongDetails isMobile />
           </Col>
-          <Col style={{ display: 'flex' }}>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                minWidth: 50,
-                marginRight: 5,
-                gap: 15,
-                justifyContent: 'space-between',
-              }}
-            >
-              <QueueButton />
-              <AddSongToLibraryButton
-                size={17}
-                isSaved={liked}
-                id={currentSong?.id!}
-                onToggle={() => {
-                  dispatch(spotifyActions.setLiked({ liked: !liked }));
+            <Col style={{ display: 'flex' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  minWidth: 50,
+                  marginRight: 5,
+                  gap: 15,
+                  justifyContent: 'space-between',
                 }}
-              />
-              <PlayButton />
-            </div>
-          </Col>
+              >
+                <DeviceButton />
+                <QueueButton />
+                <AddSongToLibraryButton
+                  size={17}
+                  isSaved={liked}
+                  id={currentSong?.id!}
+                  onToggle={() => {
+                    dispatch(spotifyActions.setLiked({ liked: !liked }));
+                  }}
+                />
+                <PlayButton />
+              </div>
+            </Col>
         </Row>
         <div className='time-line'>
           <div


### PR DESCRIPTION
## Summary
- create reusable DeviceButton component for selecting playback devices
- show DeviceButton in mobile player so mobile UI can connect to devices

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6891c37135f4832bacc746150d4bdc66