### PR TITLE
feat: fetch playlist tracks sequentially

### DIFF
--- a/src/pages/Playlist/table/index.tsx
+++ b/src/pages/Playlist/table/index.tsx
@@ -1,5 +1,5 @@
 // Components
-import { Divider } from 'antd';
+import { Divider, Button } from 'antd';
 import SongView from './Song';
 import { PlaylistTableHeader } from './header';
 import { PlaylistControls } from '../controls';
@@ -95,6 +95,14 @@ export const PlaylistList: FC<PlaylistListProps> = memo(({ color }) => {
           </div>
         ) : null}
       </InfiniteScroll>
+
+      {tracks.length < playlist?.tracks?.total! && (
+        <div style={{ textAlign: 'center', padding: '10px 0' }}>
+          <Button onClick={() => dispatch(playlistActions.getNextTracks())}>
+            Load more
+          </Button>
+        </div>
+      )}
 
       <PlaylistRecommendations />
     </div>

--- a/src/services/playlists.ts
+++ b/src/services/playlists.ts
@@ -22,7 +22,7 @@ interface GetPlaylistItemsParams extends PaginationQueryParams {
  */
 const getPlaylistItems = async (
   playlistId: string,
-  params: GetPlaylistItemsParams = { limit: 50 }
+  params: GetPlaylistItemsParams = { limit: 100 }
 ) => {
   return axios.get<Pagination<PlaylistItem>>(`/playlists/${playlistId}/tracks`, { params });
 };

--- a/src/store/slices/playlist.ts
+++ b/src/store/slices/playlist.ts
@@ -129,13 +129,17 @@ export const getNextTracks = createAsyncThunk<PlaylistItemWithSaved[]>(
   async (_params, { getState }) => {
     const { playlist, tracks } = (getState() as RootState).playlist;
 
-    const total = playlist!.tracks.total;
+    if (!playlist) {
+      return [];
+    }
+
+    const total = playlist.tracks?.total ?? 0;
     let offset = tracks.length;
     const limit = 100;
     const collected: PlaylistItemWithSaved[] = [];
 
     while (offset < total) {
-      const { data } = await playlistService.getPlaylistItems(playlist!.id, {
+      const { data } = await playlistService.getPlaylistItems(playlist.id, {
         offset,
         limit,
       });


### PR DESCRIPTION
## Summary
- allow larger playlist item batch size
- load all remaining playlist tracks sequentially
- add manual "Load more" trigger for playlists

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6891d95f73c0832ba91f6c720ababaa9