### PR TITLE
feat: add refresh token timer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,12 @@ import { Route, BrowserRouter as Router, Routes, useLocation } from 'react-route
 import { Provider } from 'react-redux';
 import { uiActions } from './store/slices/ui';
 import { PersistGate } from 'redux-persist/integration/react';
-import { authActions, loginToSpotify } from './store/slices/auth';
+import {
+  authActions,
+  loginToSpotify,
+  initRefreshTokenTimer,
+  clearRefreshTokenTimer,
+} from './store/slices/auth';
 import { persistor, store, useAppDispatch, useAppSelector } from './store/store';
 
 // Spotify
@@ -67,10 +72,15 @@ const SpotifyContainer: FC<{ children: any }> = memo(({ children }) => {
     dispatch(authActions.setToken({ token: tokenInLocalStorage }));
 
     if (tokenInLocalStorage) {
+      initRefreshTokenTimer(dispatch);
       dispatch(authActions.fetchUser());
     } else {
       dispatch(loginToSpotify(true));
     }
+
+    return () => {
+      clearRefreshTokenTimer();
+    };
   }, [dispatch]);
 
   const webPlaybackSdkProps: WebPlaybackProps = useMemo(

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -20,10 +20,10 @@ axios.interceptors.response.use(
   (error) => {
     if (error.response.status === 401) {
       return getRefreshToken()
-        .then((token) => {
-          if (!token) return Promise.reject(error);
-          axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
-          error.config.headers['Authorization'] = 'Bearer ' + token;
+        .then((data) => {
+          if (!data?.access_token) return Promise.reject(error);
+          axios.defaults.headers.common['Authorization'] = 'Bearer ' + data.access_token;
+          error.config.headers['Authorization'] = 'Bearer ' + data.access_token;
           return axios(error.config);
         })
         .catch(() => {

--- a/src/store/slices/auth.ts
+++ b/src/store/slices/auth.ts
@@ -10,6 +10,7 @@ import { authService } from '../../services/auth';
 // Interfaces
 import type { User } from '../../interfaces/user';
 import { getFromLocalStorageWithExpiry } from '../../utils/localstorage';
+import type { AppDispatch } from '../store';
 
 const initialState: { token?: string; playerLoaded: boolean; user?: User; requesting: boolean } = {
   user: undefined,
@@ -18,7 +19,11 @@ const initialState: { token?: string; playerLoaded: boolean; user?: User; reques
   token: getFromLocalStorageWithExpiry('access_token') || undefined,
 };
 
-export const loginToSpotify = createAsyncThunk<{ token?: string; loaded: boolean }, boolean>(
+export const loginToSpotify = createAsyncThunk<
+  { token?: string; loaded: boolean },
+  boolean,
+  { dispatch: AppDispatch }
+>(
   'auth/loginToSpotify',
   async (anonymous, api) => {
     const userToken: string | undefined = getFromLocalStorageWithExpiry('access_token') as string;
@@ -29,6 +34,7 @@ export const loginToSpotify = createAsyncThunk<{ token?: string; loaded: boolean
     if (token) {
       axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
       if (userToken) api.dispatch(fetchUser());
+      initRefreshTokenTimer(api.dispatch);
       return { token, loaded: false };
     }
 
@@ -39,6 +45,7 @@ export const loginToSpotify = createAsyncThunk<{ token?: string; loaded: boolean
       login.logInWithSpotify(anonymous);
     } else {
       axios.defaults.headers.common['Authorization'] = 'Bearer ' + requestedToken;
+      initRefreshTokenTimer(api.dispatch);
     }
 
     return { token: requestedToken, loaded: true };
@@ -77,5 +84,39 @@ const authSlice = createSlice({
 });
 
 export const authActions = { ...authSlice.actions, loginToSpotify, fetchUser };
+
+let refreshTokenTimeout: ReturnType<typeof setTimeout> | undefined;
+
+function scheduleRefreshToken(expiresIn: number, dispatch: AppDispatch) {
+  if (refreshTokenTimeout) clearTimeout(refreshTokenTimeout);
+  const refreshTime = Math.max(expiresIn * 1000 - 60 * 1000, 0);
+  refreshTokenTimeout = setTimeout(async () => {
+    const data = await login.getRefreshToken();
+    if (data?.access_token && data?.expires_in) {
+      dispatch(authActions.setToken({ token: data.access_token }));
+      scheduleRefreshToken(data.expires_in, dispatch);
+    }
+  }, refreshTime);
+}
+
+export function initRefreshTokenTimer(dispatch: AppDispatch) {
+  const stored = localStorage.getItem('access_token');
+  const hasRefresh = localStorage.getItem('refresh_token');
+  if (!stored || !hasRefresh) return;
+  try {
+    const { expiry } = JSON.parse(stored);
+    const expiresIn = Math.floor((expiry - Date.now()) / 1000);
+    if (expiresIn > 0) scheduleRefreshToken(expiresIn, dispatch);
+  } catch {
+    // ignore parse errors
+  }
+}
+
+export function clearRefreshTokenTimer() {
+  if (refreshTokenTimeout) {
+    clearTimeout(refreshTokenTimeout);
+    refreshTokenTimeout = undefined;
+  }
+}
 
 export default authSlice.reducer;

--- a/src/utils/spotify/login.ts
+++ b/src/utils/spotify/login.ts
@@ -171,7 +171,7 @@ export const getRefreshToken = async () => {
   if (response.refresh_token) {
     localStorage.setItem('refresh_token', response.refresh_token);
   }
-  return response.access_token;
+  return { access_token: response.access_token, expires_in: response.expires_in };
 };
 
 export default { logInWithSpotify, getToken, getRefreshToken };


### PR DESCRIPTION
## Summary
- schedule refresh token retrieval before access tokens expire
- expose timer helpers and use them on app init
- extend refresh handler to return expiry and update axios interceptor
- type refresh timer dispatch for build compatibility

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689230210500832b9d5b64b201c0158d