### PR TITLE
Remove source link and route logo to home

### DIFF
--- a/src/components/Layout/components/Navbar/Header.tsx
+++ b/src/components/Layout/components/Navbar/Header.tsx
@@ -15,7 +15,6 @@ import { useAppDispatch, useAppSelector } from '../../../../store/store';
 
 // Constants
 import { ARTISTS_DEFAULT_IMAGE } from '../../../../constants/spotify';
-import useIsMobile from '../../../../utils/isMobile';
 
 const LoginButton = () => {
   const { t } = useTranslation(['home']);
@@ -45,7 +44,6 @@ const LoginButton = () => {
 };
 
 const Header = ({ opacity }: { opacity: number; title?: string }) => {
-  const isMobile = useIsMobile();
   const { t } = useTranslation(['navbar']);
 
   const user = useAppSelector(
@@ -60,17 +58,6 @@ const Header = ({ opacity }: { opacity: number; title?: string }) => {
     >
       <div className='flex flex-row items-center'>
         <Space>
-          {!isMobile ? (
-            <a
-              target='_blank'
-              rel='noreferrer'
-              className='contact-me'
-              href='https://github.com/francoborrelli/spotify-react-web-client'
-            >
-              <span>{t('Source code')}</span>
-            </a>
-          ) : null}
-
           {/*
           <div className='news'>
             <News />

--- a/src/components/Layout/components/Navbar/HistoryNavigation.tsx
+++ b/src/components/Layout/components/Navbar/HistoryNavigation.tsx
@@ -6,15 +6,17 @@ import ForwardBackwardsButton from './ForwardBackwardsButton';
 import { useTranslation } from 'react-i18next';
 import { memo } from 'react';
 import { FaSpotify } from 'react-icons/fa6';
+import { useNavigate } from 'react-router-dom';
 
 const HistoryNavigation = memo(() => {
   const { t } = useTranslation(['navbar']);
+  const navigate = useNavigate();
   return (
     <Space>
       <NavigationButton
-        text={t('Source code')}
+        text={t('Home')}
         onClick={() => {
-          window.open('https://github.com/francoborrelli/portfolio', '_blank');
+          navigate('/');
         }}
         icon={<FaSpotify size={25} fill='white' />}
       />

--- a/src/i18n/es/navbar.ts
+++ b/src/i18n/es/navbar.ts
@@ -6,7 +6,6 @@ export const navbar = {
   'Expand your library': 'Expandir tu biblioteca',
   Language: 'Idioma',
   'Contact me': 'Contactame',
-  'Source code': 'Código fuente',
   SearchPlaceholder: '¿Qué querés reproducir?',
   'Create a new Playlist': 'Crear una nueva Playlist',
   Playlists: 'Playlists',

--- a/src/i18n/es/playingBar.ts
+++ b/src/i18n/es/playingBar.ts
@@ -7,7 +7,6 @@ export const playingBar = {
   Unmute: 'Activar sonido',
   'Full Screen': 'Expandir pantalla',
   Home: 'Inicio',
-  'Source code': 'Código fuente',
   'Your Library': 'Tu biblioteca',
   'Now playing': 'Reproduciendo',
   Next: 'A continuación',


### PR DESCRIPTION
## Summary
- remove source code link from navbar header
- make logo button navigate to the home page
- clean up unused Spanish translations

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6892d83b07d4832b948c1efc9864920f