### PR TITLE
Show durations in queue

### DIFF
--- a/src/components/Layout/components/NowPlaying/Queue/SongDetails.tsx
+++ b/src/components/Layout/components/NowPlaying/Queue/SongDetails.tsx
@@ -4,13 +4,15 @@ import { useAppSelector } from '../../../../../store/store';
 import { playerService } from '../../../../../services/player';
 import { Episode } from '../../../../../interfaces/episode';
 import useIsMobile from '../../../../../utils/isMobile';
+import { msToTime } from '../../../../../utils';
 
 interface QueueSongDetailsProps {
   song: Spotify.Track | Episode;
-  isPlaying: boolean;
+  isPlaying?: boolean;
+  extendedTracks: string[];
 }
 
-const QueueSongDetails: FC<QueueSongDetailsProps> = memo(({ song, isPlaying }) => {
+const QueueSongDetails: FC<QueueSongDetailsProps> = memo(({ song, isPlaying, extendedTracks }) => {
   const isMobile = useIsMobile();
   const queue = useAppSelector((state) => state.queue.queue);
   const isPaused = useAppSelector((state) => state.spotify.state?.paused);
@@ -54,6 +56,13 @@ const QueueSongDetails: FC<QueueSongDetailsProps> = memo(({ song, isPlaying }) =
     return '';
   }, [song]);
 
+  const duration = useMemo(() => {
+    if (extendedTracks.includes(song.name)) {
+      return '0:00-0:50';
+    }
+    return `0:00-${msToTime(song.duration_ms)}`;
+  }, [extendedTracks, song]);
+
   return (
     <div
       className='queue-song'
@@ -76,6 +85,7 @@ const QueueSongDetails: FC<QueueSongDetailsProps> = memo(({ song, isPlaying }) =
             className={`text-white font-bold song-title ${isPlaying ? 'active' : ''}`}
           >
             {song.name}
+            <span className='text-gray-300 ml-2'>{duration}</span>
           </p>
           <p className='text-gray-200 song-artist' title={artists}>
             {artists}

--- a/src/components/Layout/components/NowPlaying/Queue/index.tsx
+++ b/src/components/Layout/components/NowPlaying/Queue/index.tsx
@@ -1,10 +1,11 @@
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NowPlayingLayout } from '../layout';
 import { useAppSelector } from '../../../../../store/store';
 
 import QueueSongDetailsProps from './SongDetails';
 
-const NowPlaying = () => {
+const NowPlaying = ({ extendedTracks }: { extendedTracks: string[] }) => {
   const [t] = useTranslation(['playingBar']);
   const song = useAppSelector(
     (state) => state.spotify.state?.track_window.current_track,
@@ -16,13 +17,13 @@ const NowPlaying = () => {
     <div>
       <p className='playing-section-title'>{t('Now playing')}</p>
       <div style={{ margin: 5 }}>
-        <QueueSongDetailsProps song={song} isPlaying={true} />
+        <QueueSongDetailsProps song={song} isPlaying={true} extendedTracks={extendedTracks} />
       </div>
     </div>
   );
 };
 
-const Queueing = () => {
+const Queueing = ({ extendedTracks }: { extendedTracks: string[] }) => {
   const [t] = useTranslation(['playingBar']);
   const queue = useAppSelector((state) => state.queue.queue);
 
@@ -34,8 +35,7 @@ const Queueing = () => {
 
       <div style={{ margin: 5 }}>
         {queue.map((q, index) => (
-          // @ts-ignore
-          <QueueSongDetailsProps key={index} song={q} />
+          <QueueSongDetailsProps key={index} song={q} extendedTracks={extendedTracks} />
         ))}
       </div>
     </div>
@@ -44,12 +44,24 @@ const Queueing = () => {
 
 export const Queue = () => {
   const [t] = useTranslation(['playingBar']);
+  const [extendedTracks, setExtendedTracks] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetch(
+      'https://gist.githubusercontent.com/ochowei/8bbdfea9e0eff3fb6762218796119b7d/raw/069d2d270e8ca096fabc2dc530760374043bc7d4/extendedTimeoutTracks.json',
+    )
+      .then((res) => res.json())
+      .then((tracks: string[]) => setExtendedTracks(tracks))
+      .catch((err) => {
+        console.error('Failed to load extended timeout tracks', err);
+      });
+  }, []);
 
   return (
     <NowPlayingLayout title={t('Queue')}>
       <div style={{ marginTop: 20 }}>
-        <NowPlaying />
-        <Queueing />
+        <NowPlaying extendedTracks={extendedTracks} />
+        <Queueing extendedTracks={extendedTracks} />
       </div>
     </NowPlayingLayout>
   );


### PR DESCRIPTION
## Summary
- display track durations in queue
- fetch extended timeout track list from gist and show 0:00-0:50 for matches
- web playback uses the same gist list to limit playback

## Testing
- `CI=true npm test --silent` *(fails: No tests found, exit 1)*

------
https://chatgpt.com/codex/tasks/task_e_689314440a60832b86b19ab9fd95d715