### PR TITLE
feat: configure extended timeout tracks URL via env

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,2 +1,3 @@
 REACT_APP_SPOTIFY_CLIENT_ID=
 REACT_APP_SPOTIFY_REDIRECT_URL=http://localhost:3000
+REACT_APP_EXTENDED_TIMEOUT_TRACKS_URL=https://gist.githubusercontent.com/ochowei/8bbdfea9e0eff3fb6762218796119b7d/raw/069d2d270e8ca096fabc2dc530760374043bc7d4/extendedTimeoutTracks.json

--- a/src/utils/spotify/webPlayback.tsx
+++ b/src/utils/spotify/webPlayback.tsx
@@ -31,11 +31,15 @@ const WebPlayback: FC<WebPlaybackProps> = memo((props) => {
   const trackTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const currentTrackIdRef = useRef<string | null>(null);
   const extendedTimeoutTracksRef = useRef<Set<string>>(new Set());
+  const extendedTimeoutTracksUrl =
+    process.env.REACT_APP_EXTENDED_TIMEOUT_TRACKS_URL;
 
   useEffect(() => {
-    fetch(
-      'https://gist.githubusercontent.com/ochowei/8bbdfea9e0eff3fb6762218796119b7d/raw/069d2d270e8ca096fabc2dc530760374043bc7d4/extendedTimeoutTracks.json',
-    )
+    if (!extendedTimeoutTracksUrl) {
+      return;
+    }
+
+    fetch(extendedTimeoutTracksUrl)
       .then((res) => res.json())
       .then((tracks: string[]) => {
         extendedTimeoutTracksRef.current = new Set(tracks);
@@ -43,7 +47,7 @@ const WebPlayback: FC<WebPlaybackProps> = memo((props) => {
       .catch((err) => {
         console.error('Failed to load extended timeout tracks', err);
       });
-  }, []);
+  }, [extendedTimeoutTracksUrl]);
 
   const handleState = async (state: any | null) => {
     if (state) {


### PR DESCRIPTION
## Summary
- load extended timeout track list from configurable URL
- expose URL through `REACT_APP_EXTENDED_TIMEOUT_TRACKS_URL`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68931f533afc832b9d0f9a3457a7f8f4