### PR TITLE
feat: display queue track duration

### DIFF
--- a/src/components/Layout/components/NowPlaying/Queue/SongDetails.tsx
+++ b/src/components/Layout/components/NowPlaying/Queue/SongDetails.tsx
@@ -3,10 +3,11 @@ import { Pause, Play } from '../../../../Icons';
 import { useAppSelector } from '../../../../../store/store';
 import { playerService } from '../../../../../services/player';
 import { Episode } from '../../../../../interfaces/episode';
+import type { Track as ApiTrack } from '../../../../../interfaces/track';
 import useIsMobile from '../../../../../utils/isMobile';
 
 interface QueueSongDetailsProps {
-  song: Spotify.Track | Episode;
+  song: Spotify.Track | ApiTrack | Episode;
   isPlaying?: boolean;
   durationText: string;
 }

--- a/src/components/Layout/components/NowPlaying/Queue/SongDetails.tsx
+++ b/src/components/Layout/components/NowPlaying/Queue/SongDetails.tsx
@@ -7,10 +7,11 @@ import useIsMobile from '../../../../../utils/isMobile';
 
 interface QueueSongDetailsProps {
   song: Spotify.Track | Episode;
-  isPlaying: boolean;
+  isPlaying?: boolean;
+  durationText: string;
 }
 
-const QueueSongDetails: FC<QueueSongDetailsProps> = memo(({ song, isPlaying }) => {
+const QueueSongDetails: FC<QueueSongDetailsProps> = memo(({ song, isPlaying, durationText }) => {
   const isMobile = useIsMobile();
   const queue = useAppSelector((state) => state.queue.queue);
   const isPaused = useAppSelector((state) => state.spotify.state?.paused);
@@ -76,6 +77,7 @@ const QueueSongDetails: FC<QueueSongDetailsProps> = memo(({ song, isPlaying }) =
             className={`text-white font-bold song-title ${isPlaying ? 'active' : ''}`}
           >
             {song.name}
+            <span className='song-duration text-gray-400 text-xs ml-2'>({durationText})</span>
           </p>
           <p className='text-gray-200 song-artist' title={artists}>
             {artists}

--- a/src/components/Layout/components/NowPlaying/Queue/index.tsx
+++ b/src/components/Layout/components/NowPlaying/Queue/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { NowPlayingLayout } from '../layout';
 import { useAppSelector } from '../../../../../store/store';
 
-import QueueSongDetailsProps from './SongDetails';
+import QueueSongDetails from './SongDetails';
 
 interface NowPlayingProps {
   extendedTracks: Set<string>;
@@ -23,7 +23,7 @@ const NowPlaying = ({ extendedTracks }: NowPlayingProps) => {
     <div>
       <p className='playing-section-title'>{t('Now playing')}</p>
       <div style={{ margin: 5 }}>
-        <QueueSongDetailsProps song={song} isPlaying={true} durationText={durationText} />
+        <QueueSongDetails song={song} isPlaying={true} durationText={durationText} />
       </div>
     </div>
   );
@@ -46,7 +46,7 @@ const Queueing = ({ extendedTracks }: QueueingProps) => {
       <div style={{ margin: 5 }}>
         {queue.map((q, index) => {
           const durationText = extendedTracks.has(q.name) ? '0:00-0:50' : 'full song';
-          return <QueueSongDetailsProps key={index} song={q} durationText={durationText} />;
+          return <QueueSongDetails key={index} song={q} durationText={durationText} />;
         })}
       </div>
     </div>

--- a/src/components/Layout/components/NowPlaying/Queue/index.tsx
+++ b/src/components/Layout/components/NowPlaying/Queue/index.tsx
@@ -1,10 +1,15 @@
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NowPlayingLayout } from '../layout';
 import { useAppSelector } from '../../../../../store/store';
 
 import QueueSongDetailsProps from './SongDetails';
 
-const NowPlaying = () => {
+interface NowPlayingProps {
+  extendedTracks: Set<string>;
+}
+
+const NowPlaying = ({ extendedTracks }: NowPlayingProps) => {
   const [t] = useTranslation(['playingBar']);
   const song = useAppSelector(
     (state) => state.spotify.state?.track_window.current_track,
@@ -12,17 +17,23 @@ const NowPlaying = () => {
   );
   if (!song) return null;
 
+  const durationText = extendedTracks.has(song.name) ? '0:00-0:50' : 'full song';
+
   return (
     <div>
       <p className='playing-section-title'>{t('Now playing')}</p>
       <div style={{ margin: 5 }}>
-        <QueueSongDetailsProps song={song} isPlaying={true} />
+        <QueueSongDetailsProps song={song} isPlaying={true} durationText={durationText} />
       </div>
     </div>
   );
 };
 
-const Queueing = () => {
+interface QueueingProps {
+  extendedTracks: Set<string>;
+}
+
+const Queueing = ({ extendedTracks }: QueueingProps) => {
   const [t] = useTranslation(['playingBar']);
   const queue = useAppSelector((state) => state.queue.queue);
 
@@ -33,10 +44,10 @@ const Queueing = () => {
       <p className='playing-section-title'>{t('Next')}</p>
 
       <div style={{ margin: 5 }}>
-        {queue.map((q, index) => (
-          // @ts-ignore
-          <QueueSongDetailsProps key={index} song={q} />
-        ))}
+        {queue.map((q, index) => {
+          const durationText = extendedTracks.has(q.name) ? '0:00-0:50' : 'full song';
+          return <QueueSongDetailsProps key={index} song={q} durationText={durationText} />;
+        })}
       </div>
     </div>
   );
@@ -44,12 +55,26 @@ const Queueing = () => {
 
 export const Queue = () => {
   const [t] = useTranslation(['playingBar']);
+  const [extendedTracks, setExtendedTracks] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const url = process.env.REACT_APP_EXTENDED_TIMEOUT_TRACKS_URL;
+    if (!url) return;
+    fetch(url)
+      .then((res) => res.json())
+      .then((tracks: string[]) => {
+        setExtendedTracks(new Set(tracks));
+      })
+      .catch((err) => {
+        console.error('Failed to load extended timeout tracks', err);
+      });
+  }, []);
 
   return (
     <NowPlayingLayout title={t('Queue')}>
       <div style={{ marginTop: 20 }}>
-        <NowPlaying />
-        <Queueing />
+        <NowPlaying extendedTracks={extendedTracks} />
+        <Queueing extendedTracks={extendedTracks} />
       </div>
     </NowPlayingLayout>
   );


### PR DESCRIPTION
## Summary
- show playback duration beside songs in queue
- use REACT_APP_EXTENDED_TIMEOUT_TRACKS_URL to display `0:00-0:50` for listed tracks

## Testing
- `CI=1 npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6893277ac5c4832b88f346c33dd7c07f