### PR TITLE
fix: refresh access token for web playback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,7 @@ const SpotifyContainer: FC<{ children: any }> = memo(({ children }) => {
   const dispatch = useAppDispatch();
 
   const user = useAppSelector((state) => !!state.auth.user);
-  const token = useAppSelector((state) => state.auth.token);
+  // Removed token selector; access token is retrieved directly from localStorage when needed
   const requesting = useAppSelector((state) => state.auth.requesting);
 
   useEffect(() => {
@@ -89,7 +89,9 @@ const SpotifyContainer: FC<{ children: any }> = memo(({ children }) => {
       playerInitialVolume: 1.0,
       playerRefreshRateMs: 1000,
       playerName: 'Spotify React Player',
-      onPlayerRequestAccessToken: () => Promise.resolve(token!),
+      // Read the latest access token from localStorage each time the player requests it
+      onPlayerRequestAccessToken: () =>
+        Promise.resolve(getFromLocalStorageWithExpiry('access_token') || ''),
       onPlayerLoading: () => {},
       onPlayerWaitingForDevice: () => {
         dispatch(authActions.setPlayerLoaded({ playerLoaded: true }));
@@ -101,7 +103,7 @@ const SpotifyContainer: FC<{ children: any }> = memo(({ children }) => {
         dispatch(authActions.setPlayerLoaded({ playerLoaded: true }));
       },
     }),
-    [dispatch, token]
+    [dispatch]
   );
 
   if (!user) return <Spinner loading={requesting}>{children}</Spinner>;


### PR DESCRIPTION
## Summary
- ensure Web Playback fetches an up-to-date access token by reading it from localStorage whenever requested

## Testing
- `CI=1 npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68932bf84f70832ba58445f4e600fe66