### PR TITLE
fix: show truncated time for extended tracks in playlist

### DIFF
--- a/src/pages/Playlist/table/Song.tsx
+++ b/src/pages/Playlist/table/Song.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { PlaylistItemWithSaved } from '../../../interfaces/playlists';
 import SongView, { SongViewComponents } from '../../../components/SongsTable/songView';
+import { msToTime } from '../../../utils';
 
 // Redux
 import { playlistActions } from '../../../store/slices/playlist';
@@ -9,10 +10,11 @@ import { useAppDispatch, useAppSelector } from '../../../store/store';
 interface SongProps {
   index: number;
   song: PlaylistItemWithSaved;
+  extendedTracks: Set<string>;
 }
 
 export const Song = (props: SongProps) => {
-  const { song, index } = props;
+  const { song, index, extendedTracks } = props;
 
   const dispatch = useAppDispatch();
   const view = useAppSelector((state) => state.playlist.view);
@@ -44,7 +46,19 @@ export const Song = (props: SongProps) => {
         SongViewComponents.Album,
         SongViewComponents.AddedAt,
         (props) => <SongViewComponents.AddToLiked {...props} onLikeRefresh={toggleLike} />,
-        SongViewComponents.Time,
+        (props) => {
+          const duration = extendedTracks.has(props.song.name)
+            ? '0:50'
+            : msToTime(props.song.duration_ms);
+          return (
+            <p
+              className='text-right '
+              style={{ flex: 1, display: 'flex', justifyContent: 'end' }}
+            >
+              {duration}
+            </p>
+          );
+        },
         SongViewComponents.Actions,
       ]}
     />

--- a/src/pages/Playlist/table/index.tsx
+++ b/src/pages/Playlist/table/index.tsx
@@ -17,7 +17,7 @@ import { useAppDispatch, useAppSelector } from '../../../store/store';
 import { DEFAULT_PAGE_COLOR } from '../../../constants/spotify';
 
 // Interfaces
-import { memo, type FC } from 'react';
+import { memo, type FC, useEffect, useState } from 'react';
 import InfiniteScroll from 'react-infinite-scroll-component';
 
 interface PlaylistListProps {
@@ -29,6 +29,21 @@ export const PlaylistList: FC<PlaylistListProps> = memo(({ color }) => {
   const tracks = useAppSelector((state) => state.playlist.tracks);
   const canEdit = useAppSelector((state) => state.playlist.canEdit);
   const playlist = useAppSelector((state) => state.playlist.playlist);
+
+  const [extendedTracks, setExtendedTracks] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const url = process.env.REACT_APP_EXTENDED_TIMEOUT_TRACKS_URL;
+    if (!url) return;
+    fetch(url)
+      .then((res) => res.json())
+      .then((tracks: string[]) => {
+        setExtendedTracks(new Set(tracks));
+      })
+      .catch((err) => {
+        console.error('Failed to load extended timeout tracks', err);
+      });
+  }, []);
 
   const hasTracks = !!playlist?.tracks?.total;
 
@@ -81,14 +96,24 @@ export const PlaylistList: FC<PlaylistListProps> = memo(({ color }) => {
                   }}
                 >
                   {tracks.map((song, index) => (
-                    <SongView song={song} key={`${song.added_at}-${song.track.id}`} index={index} />
+                    <SongView
+                      song={song}
+                      key={`${song.added_at}-${song.track.id}`}
+                      index={index}
+                      extendedTracks={extendedTracks}
+                    />
                   ))}
                 </ReactDragListView>
               </div>
             ) : (
               <div>
                 {tracks.map((song, index) => (
-                  <SongView song={song} key={`${song.added_at}-${song.track.id}`} index={index} />
+                  <SongView
+                    song={song}
+                    key={`${song.added_at}-${song.track.id}`}
+                    index={index}
+                    extendedTracks={extendedTracks}
+                  />
                 ))}
               </div>
             )}


### PR DESCRIPTION
## Summary
- load extended timeout track list and pass to playlist songs
- show 0:50 duration for tracks that auto-skip after 50 seconds

## Testing
- `CI=1 npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68933d45152c832b9e4220fb703d1b02