### PR TITLE
feat: add logout button

### DIFF
--- a/src/components/Layout/components/Navbar/Header.tsx
+++ b/src/components/Layout/components/Navbar/Header.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 // Redux
 import { uiActions } from '../../../../store/slices/ui';
-import { loginToSpotify } from '../../../../store/slices/auth';
+import { loginToSpotify, logout } from '../../../../store/slices/auth';
 import { useAppDispatch, useAppSelector } from '../../../../store/store';
 
 // Constants
@@ -45,7 +45,7 @@ const LoginButton = () => {
 
 const Header = ({ opacity }: { opacity: number; title?: string }) => {
   const { t } = useTranslation(['navbar']);
-
+  const dispatch = useAppDispatch();
   const user = useAppSelector(
     (state) => state.auth.user,
     (prev, next) => prev?.id === next?.id
@@ -64,19 +64,26 @@ const Header = ({ opacity }: { opacity: number; title?: string }) => {
           </div> */}
 
           {user ? (
-            <div className='avatar-container'>
-              <Link to={`/users/${user!.id}`}>
-                <img
-                  className='avatar'
-                  id='user-avatar'
-                  alt='User Avatar'
-                  style={{ marginTop: -1 }}
-                  src={
-                    user?.images && user.images.length ? user.images[0].url : ARTISTS_DEFAULT_IMAGE
-                  }
-                />
-              </Link>
-            </div>
+            <>
+              <div className='avatar-container'>
+                <Link to={`/users/${user!.id}`}>
+                  <img
+                    className='avatar'
+                    id='user-avatar'
+                    alt='User Avatar'
+                    style={{ marginTop: -1 }}
+                    src={
+                      user?.images && user.images.length ? user.images[0].url : ARTISTS_DEFAULT_IMAGE
+                    }
+                  />
+                </Link>
+              </div>
+              <WhiteButton
+                size='small'
+                title={t('Log Out')}
+                onClick={() => dispatch(logout())}
+              />
+            </>
           ) : (
             <LoginButton />
           )}

--- a/src/i18n/en/navbar.ts
+++ b/src/i18n/en/navbar.ts
@@ -10,4 +10,5 @@ export const navbar = {
   COMPACT: 'Compact',
   GRID: 'Grid',
   LIST: 'List',
+  'Log Out': 'Log Out',
 };

--- a/src/i18n/es/navbar.ts
+++ b/src/i18n/es/navbar.ts
@@ -16,4 +16,5 @@ export const navbar = {
   GRID: 'Grilla',
   LIST: 'Lista',
   'Log In': 'Iniciar sesión',
+  'Log Out': 'Cerrar sesión',
 };

--- a/src/store/slices/auth.ts
+++ b/src/store/slices/auth.ts
@@ -57,6 +57,15 @@ export const fetchUser = createAsyncThunk('auth/fetchUser', async () => {
   return response.data;
 });
 
+export const logout = createAsyncThunk('auth/logout', async () => {
+  clearRefreshTokenTimer();
+  localStorage.removeItem('access_token');
+  localStorage.removeItem('public_access_token');
+  localStorage.removeItem('refresh_token');
+  localStorage.removeItem('code_verifier');
+  delete axios.defaults.headers.common['Authorization'];
+});
+
 const authSlice = createSlice({
   name: 'auth',
   initialState,
@@ -80,10 +89,16 @@ const authSlice = createSlice({
       state.user = action.payload;
       state.requesting = false;
     });
+    builder.addCase(logout.fulfilled, (state) => {
+      state.token = undefined;
+      state.user = undefined;
+      state.playerLoaded = false;
+      state.requesting = false;
+    });
   },
 });
 
-export const authActions = { ...authSlice.actions, loginToSpotify, fetchUser };
+export const authActions = { ...authSlice.actions, loginToSpotify, fetchUser, logout };
 
 let refreshTokenTimeout: ReturnType<typeof setTimeout> | undefined;
 


### PR DESCRIPTION
## Summary
- add logout thunk to clear tokens and state
- show new Log Out button in header
- localize Log Out text for EN and ES

## Testing
- `CI=1 npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68933d7a23f8832bb4e2bededa2b7dbd