### PR TITLE
feat: allow homepage without forced login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ const SpotifyContainer: FC<{ children: any }> = memo(({ children }) => {
       initRefreshTokenTimer(dispatch);
       dispatch(authActions.fetchUser());
     } else {
-      dispatch(loginToSpotify(true));
+      dispatch(authActions.setRequesting({ requesting: false }));
     }
 
     return () => {

--- a/src/pages/Home/container/header/index.tsx
+++ b/src/pages/Home/container/header/index.tsx
@@ -2,12 +2,14 @@ import { Space } from 'antd';
 import { FC, memo, RefObject } from 'react';
 import Chip from '../../../../components/Chip';
 import { PageHeader } from '../../../../components/Layout/components/Header';
+import { WhiteButton } from '../../../../components/Button';
 
 // Utils
 import { useTranslation } from 'react-i18next';
 
 // Redux
 import { homeActions } from '../../../../store/slices/home';
+import { loginToSpotify } from '../../../../store/slices/auth';
 import { useAppDispatch, useAppSelector } from '../../../../store/store';
 
 interface HomeHeaderProps {
@@ -39,11 +41,20 @@ const ChipsSection = memo(() => {
 
 export const HomeHeader: FC<HomeHeaderProps> = (props) => {
   const user = useAppSelector((state) => state.auth.user);
+  const dispatch = useAppDispatch();
+  const [t] = useTranslation(['home']);
 
   const { container, sectionContainer, color } = props;
 
   if (!user) {
-    return null;
+    return (
+      <PageHeader color={color} container={container} sectionContainer={sectionContainer}>
+        <WhiteButton
+          title={t('Log In')}
+          onClick={() => dispatch(loginToSpotify(false))}
+        />
+      </PageHeader>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- avoid auto-login when no token and render homepage
- show login button in home header for manual login

## Testing
- `CI=1 npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68936dfd536c832bb36c9fdc110a1f0d