### PR TITLE
fix: guard home ranking queries behind auth

### DIFF
--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -23,11 +23,11 @@ const Home: FC<HomeProps> = memo((props) => {
       dispatch(homeActions.fetchTopTracks());
       dispatch(homeActions.fetchMadeForYou());
       dispatch(homeActions.fetchRecentlyPlayed());
+      dispatch(homeActions.fetchRanking());
+      dispatch(homeActions.fetchTrending());
+      dispatch(homeActions.fetchNewReleases());
+      dispatch(homeActions.fecthFeaturedPlaylists());
     }
-    dispatch(homeActions.fetchRanking());
-    dispatch(homeActions.fetchTrending());
-    dispatch(homeActions.fetchNewReleases());
-    dispatch(homeActions.fecthFeaturedPlaylists());
   }, [user, dispatch]);
 
   return <HomePageContainer container={container} />;


### PR DESCRIPTION
## Summary
- avoid unauthenticated dispatches for home page ranking and discovery fetches

## Testing
- `CI=1 npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68937c43b624832b8f823d68d6dd2f7d