### PR TITLE
fix: handle missing token without redirect

### DIFF
--- a/src/store/slices/auth.ts
+++ b/src/store/slices/auth.ts
@@ -42,11 +42,10 @@ export const loginToSpotify = createAsyncThunk<
     if (requestUser) api.dispatch(fetchUser());
 
     if (!requestedToken) {
-      login.logInWithSpotify(anonymous);
-    } else {
-      axios.defaults.headers.common['Authorization'] = 'Bearer ' + requestedToken;
-      initRefreshTokenTimer(api.dispatch);
+      return { token: undefined, loaded: true };
     }
+    axios.defaults.headers.common['Authorization'] = 'Bearer ' + requestedToken;
+    initRefreshTokenTimer(api.dispatch);
 
     return { token: requestedToken, loaded: true };
   }


### PR DESCRIPTION
## Summary
- avoid redirect when token request fails
- set Authorization header and start refresh timer when token obtained

## Testing
- `CI=1 npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68941b647dcc832ba2ded9cb3dc67300