### PR TITLE
fix: prevent redirect in refresh token retrieval

### DIFF
--- a/src/utils/spotify/login.ts
+++ b/src/utils/spotify/login.ts
@@ -132,7 +132,6 @@ export const getRefreshToken = async () => {
   const refreshToken = localStorage.getItem('refresh_token') as string;
 
   if (!refreshToken) {
-    logInWithSpotify();
     return null;
   }
 
@@ -153,7 +152,6 @@ export const getRefreshToken = async () => {
   const response = await body.json();
 
   if (!response.access_token) {
-    logInWithSpotify();
     return null;
   }
 


### PR DESCRIPTION
## Summary
- stop redirecting to Spotify login when refresh token missing or invalid

## Testing
- `CI=1 npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6894243cf038832b9b6facaa7748bb50