### PR TITLE
feat: add playback time configuration modal

### DIFF
--- a/src/components/SongsTable/songView.tsx
+++ b/src/components/SongsTable/songView.tsx
@@ -1,6 +1,6 @@
-import { Tooltip } from 'antd';
+import { Tooltip, Modal, Input, InputNumber } from 'antd';
 import ReactTimeAgo from 'react-time-ago';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { MenuIcon, Pause, Play } from '../Icons';
 import { TrackActionsWrapper } from '../Actions/TrackActions';
 
@@ -263,10 +263,41 @@ const Actions = ({ song }: ComponentProps) => {
 };
 
 const Time = ({ song }: ComponentProps) => {
+  const [open, setOpen] = useState(false);
+  const [start, setStart] = useState('');
+  const [seconds, setSeconds] = useState<number | null>(null);
+
   return (
-    <p className='text-right ' style={{ flex: 1, display: 'flex', justifyContent: 'end' }}>
-      {msToTime(song.duration_ms)}
-    </p>
+    <>
+      <p
+        className='text-right '
+        style={{ flex: 1, display: 'flex', justifyContent: 'end', alignItems: 'center' }}
+      >
+        {msToTime(song.duration_ms)}
+        <button className='ml-2 text-xs' onClick={() => setOpen(true)}>
+          設定
+        </button>
+      </p>
+      <Modal
+        open={open}
+        onOk={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+        title='設定播放時間'
+      >
+        <Input
+          placeholder='開始時間'
+          value={start}
+          onChange={(e) => setStart(e.target.value)}
+          className='mb-2'
+        />
+        <InputNumber
+          placeholder='秒數'
+          value={seconds ?? undefined}
+          onChange={(value) => setSeconds(typeof value === 'number' ? value : null)}
+          style={{ width: '100%' }}
+        />
+      </Modal>
+    </>
   );
 };
 

--- a/src/pages/Playlist/table/Song.tsx
+++ b/src/pages/Playlist/table/Song.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { PlaylistItemWithSaved } from '../../../interfaces/playlists';
 import SongView, { SongViewComponents } from '../../../components/SongsTable/songView';
 import { msToTime } from '../../../utils';
+import { Modal, Input, InputNumber } from 'antd';
 
 // Redux
 import { playlistActions } from '../../../store/slices/playlist';
@@ -20,6 +21,10 @@ export const Song = (props: SongProps) => {
   const view = useAppSelector((state) => state.playlist.view);
   const canEdit = useAppSelector((state) => state.playlist.canEdit);
   const playlist = useAppSelector((state) => state.playlist.playlist);
+
+  const [open, setOpen] = useState(false);
+  const [start, setStart] = useState('');
+  const [seconds, setSeconds] = useState<number | null>(null);
 
   const toggleLike = useCallback(() => {
     dispatch(playlistActions.setTrackLikeState({ id: song.track.id, saved: !song.saved }));
@@ -51,12 +56,43 @@ export const Song = (props: SongProps) => {
             ? '0:50'
             : msToTime(props.song.duration_ms);
           return (
-            <p
-              className='text-right '
-              style={{ flex: 1, display: 'flex', justifyContent: 'end' }}
-            >
-              {duration}
-            </p>
+            <>
+              <p
+                className='text-right '
+                style={{
+                  flex: 1,
+                  display: 'flex',
+                  justifyContent: 'end',
+                  alignItems: 'center',
+                }}
+              >
+                {duration}
+                <button className='ml-2 text-xs' onClick={() => setOpen(true)}>
+                  設定
+                </button>
+              </p>
+              <Modal
+                open={open}
+                onOk={() => setOpen(false)}
+                onCancel={() => setOpen(false)}
+                title='設定播放時間'
+              >
+                <Input
+                  placeholder='開始時間'
+                  value={start}
+                  onChange={(e) => setStart(e.target.value)}
+                  className='mb-2'
+                />
+                <InputNumber
+                  placeholder='秒數'
+                  value={seconds ?? undefined}
+                  onChange={(value) =>
+                    setSeconds(typeof value === 'number' ? value : null)
+                  }
+                  style={{ width: '100%' }}
+                />
+              </Modal>
+            </>
           );
         },
         SongViewComponents.Actions,


### PR DESCRIPTION
## Summary
- add modal to configure playback start time and duration in song list
- include trigger button beside song duration

## Testing
- `CI=1 npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689ac1802174832b9c64465f3dc2fa3a