### PR TITLE
feat: add playback time configuration modal

### DIFF
--- a/src/components/SongsTable/header.tsx
+++ b/src/components/SongsTable/header.tsx
@@ -41,7 +41,7 @@ const Album = (props: ItemProps) => {
 const DateAdded = (props: ItemProps) => {
   const { t } = useTranslation(['playlist']);
   return (
-    <div style={{ flex: 3 }}>
+    <div style={{ flex: 1.5 }}>
       <h3 className='column-name tablet-hidden text-left'>{t('Date Added')}</h3>
     </div>
   );

--- a/src/components/SongsTable/songView.tsx
+++ b/src/components/SongsTable/songView.tsx
@@ -1,6 +1,6 @@
-import { Tooltip } from 'antd';
+import { Tooltip, Modal, Input, InputNumber } from 'antd';
 import ReactTimeAgo from 'react-time-ago';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { MenuIcon, Pause, Play } from '../Icons';
 import { TrackActionsWrapper } from '../Actions/TrackActions';
 
@@ -16,6 +16,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { playerService } from '../../services/player';
 import { ArtistActionsWrapper } from '../Actions/ArtistActions';
 import { AddSongToLibraryButton } from '../Actions/AddSongToLibrary';
+import { FaGear } from 'react-icons/fa6';
 
 // Interfaces
 import type { Track } from '../../interfaces/track';
@@ -210,7 +211,7 @@ const AddedAt = ({ addedAt }: ComponentProps) => {
   const language = useAppSelector((state) => state.language.language);
   if (!addedAt) return null;
   return (
-    <p className='text-left tablet-hidden' style={{ flex: 3 }}>
+    <p className='text-left tablet-hidden' style={{ flex: 1.5 }}>
       <ReactTimeAgo date={new Date(addedAt)} locale={language === 'es' ? 'es-AR' : undefined} />
     </p>
   );
@@ -263,10 +264,41 @@ const Actions = ({ song }: ComponentProps) => {
 };
 
 const Time = ({ song }: ComponentProps) => {
+  const [open, setOpen] = useState(false);
+  const [start, setStart] = useState('');
+  const [seconds, setSeconds] = useState<number | null>(null);
+
   return (
-    <p className='text-right ' style={{ flex: 1, display: 'flex', justifyContent: 'end' }}>
-      {msToTime(song.duration_ms)}
-    </p>
+    <>
+      <p
+        className='text-right '
+        style={{ flex: 1, display: 'flex', justifyContent: 'end', alignItems: 'center' }}
+      >
+        {msToTime(song.duration_ms)}
+        <button className='ml-2' onClick={() => setOpen(true)} aria-label='設定'>
+          <FaGear size={12} />
+        </button>
+      </p>
+      <Modal
+        open={open}
+        onOk={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+        title='設定播放時間'
+      >
+        <Input
+          placeholder='開始時間'
+          value={start}
+          onChange={(e) => setStart(e.target.value)}
+          className='mb-2'
+        />
+        <InputNumber
+          placeholder='秒數'
+          value={seconds ?? undefined}
+          onChange={(value) => setSeconds(typeof value === 'number' ? value : null)}
+          style={{ width: '100%' }}
+        />
+      </Modal>
+    </>
   );
 };
 

--- a/src/pages/Playlist/table/Song.tsx
+++ b/src/pages/Playlist/table/Song.tsx
@@ -1,7 +1,9 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { PlaylistItemWithSaved } from '../../../interfaces/playlists';
 import SongView, { SongViewComponents } from '../../../components/SongsTable/songView';
 import { msToTime } from '../../../utils';
+import { Modal, Input, InputNumber } from 'antd';
+import { FaGear } from 'react-icons/fa6';
 
 // Redux
 import { playlistActions } from '../../../store/slices/playlist';
@@ -20,6 +22,10 @@ export const Song = (props: SongProps) => {
   const view = useAppSelector((state) => state.playlist.view);
   const canEdit = useAppSelector((state) => state.playlist.canEdit);
   const playlist = useAppSelector((state) => state.playlist.playlist);
+
+  const [open, setOpen] = useState(false);
+  const [start, setStart] = useState('');
+  const [seconds, setSeconds] = useState<number | null>(null);
 
   const toggleLike = useCallback(() => {
     dispatch(playlistActions.setTrackLikeState({ id: song.track.id, saved: !song.saved }));
@@ -51,12 +57,43 @@ export const Song = (props: SongProps) => {
             ? '0:50'
             : msToTime(props.song.duration_ms);
           return (
-            <p
-              className='text-right '
-              style={{ flex: 1, display: 'flex', justifyContent: 'end' }}
-            >
-              {duration}
-            </p>
+            <>
+              <p
+                className='text-right '
+                style={{
+                  flex: 1,
+                  display: 'flex',
+                  justifyContent: 'end',
+                  alignItems: 'center',
+                }}
+              >
+                {duration}
+                <button className='ml-2' onClick={() => setOpen(true)} aria-label='設定'>
+                  <FaGear size={12} />
+                </button>
+              </p>
+              <Modal
+                open={open}
+                onOk={() => setOpen(false)}
+                onCancel={() => setOpen(false)}
+                title='設定播放時間'
+              >
+                <Input
+                  placeholder='開始時間'
+                  value={start}
+                  onChange={(e) => setStart(e.target.value)}
+                  className='mb-2'
+                />
+                <InputNumber
+                  placeholder='秒數'
+                  value={seconds ?? undefined}
+                  onChange={(value) =>
+                    setSeconds(typeof value === 'number' ? value : null)
+                  }
+                  style={{ width: '100%' }}
+                />
+              </Modal>
+            </>
           );
         },
         SongViewComponents.Actions,


### PR DESCRIPTION
## Summary
- add modal to configure playback start time and duration in song list
- include trigger button beside song duration
- shorten Date Added column and replace text trigger with gear icon

## Testing
- `CI=1 npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689ac1802174832b9c64465f3dc2fa3a