### PR TITLE
feat: adjust date column width and iconize settings

### DIFF
--- a/src/components/SongsTable/header.tsx
+++ b/src/components/SongsTable/header.tsx
@@ -41,7 +41,7 @@ const Album = (props: ItemProps) => {
 const DateAdded = (props: ItemProps) => {
   const { t } = useTranslation(['playlist']);
   return (
-    <div style={{ flex: 3 }}>
+    <div style={{ flex: 1.5 }}>
       <h3 className='column-name tablet-hidden text-left'>{t('Date Added')}</h3>
     </div>
   );

--- a/src/pages/Playlist/table/Song.tsx
+++ b/src/pages/Playlist/table/Song.tsx
@@ -3,6 +3,7 @@ import { PlaylistItemWithSaved } from '../../../interfaces/playlists';
 import SongView, { SongViewComponents } from '../../../components/SongsTable/songView';
 import { msToTime } from '../../../utils';
 import { Modal, Input, InputNumber } from 'antd';
+import { FaGear } from 'react-icons/fa6';
 
 // Redux
 import { playlistActions } from '../../../store/slices/playlist';
@@ -67,8 +68,12 @@ export const Song = (props: SongProps) => {
                 }}
               >
                 {duration}
-                <button className='ml-2 text-xs' onClick={() => setOpen(true)}>
-                  設定
+                <button
+                  className='ml-2 text-xs'
+                  onClick={() => setOpen(true)}
+                  aria-label='settings'
+                >
+                  <FaGear />
                 </button>
               </p>
               <Modal


### PR DESCRIPTION
## Summary
- halve "Date Added" column width on main song table
- replace playlist track settings text with gear icon

## Testing
- `CI=1 npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689ad38b1ac4832b8ffd280cacaa52b2