### PR TITLE
feat: double song duration column width

### DIFF
--- a/src/components/SongsTable/header.tsx
+++ b/src/components/SongsTable/header.tsx
@@ -61,7 +61,7 @@ const Artists = (props: ItemProps) => {
 
 const Time = (props: ItemProps) => {
   return (
-    <div style={{ flex: 1, display: 'flex', justifyContent: 'flex-end' }}>
+    <div style={{ flex: 2, display: 'flex', justifyContent: 'flex-end' }}>
       <h3 style={{ marginRight: 10, textAlign: 'right' }}>
         <Clock />
       </h3>

--- a/src/components/SongsTable/songView.tsx
+++ b/src/components/SongsTable/songView.tsx
@@ -271,7 +271,7 @@ const Time = ({ song }: ComponentProps) => {
     <>
       <p
         className='text-right '
-        style={{ flex: 1, display: 'flex', justifyContent: 'end', alignItems: 'center' }}
+        style={{ flex: 2, display: 'flex', justifyContent: 'end', alignItems: 'center' }}
       >
         {msToTime(song.duration_ms)}
         <button className='ml-2 text-xs' onClick={() => setOpen(true)}>

--- a/src/pages/Playlist/table/Song.tsx
+++ b/src/pages/Playlist/table/Song.tsx
@@ -61,7 +61,7 @@ export const Song = (props: SongProps) => {
               <p
                 className='text-right '
                 style={{
-                  flex: 1,
+                  flex: 2,
                   display: 'flex',
                   justifyContent: 'end',
                   alignItems: 'center',


### PR DESCRIPTION
## Summary
- enlarge song duration column in song table
- adjust playlist row duration column width

## Testing
- `CI=1 npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689ad9cddec8832bbc014a42d3619f9c