### PR TITLE
fix: align date column in song table

### DIFF
--- a/src/components/SongsTable/songView.tsx
+++ b/src/components/SongsTable/songView.tsx
@@ -210,7 +210,7 @@ const AddedAt = ({ addedAt }: ComponentProps) => {
   const language = useAppSelector((state) => state.language.language);
   if (!addedAt) return null;
   return (
-    <p className='text-left tablet-hidden' style={{ flex: 3 }}>
+    <p className='text-left tablet-hidden' style={{ flex: 1.5 }}>
       <ReactTimeAgo date={new Date(addedAt)} locale={language === 'es' ? 'es-AR' : undefined} />
     </p>
   );


### PR DESCRIPTION
## Summary
- ensure Date Added column matches header width in song tables

## Testing
- `CI=1 npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae07b2ac4832ba8502c58a81f8816