### PR TITLE
feat: use separate inputs for start time

### DIFF
--- a/src/components/SongsTable/songView.tsx
+++ b/src/components/SongsTable/songView.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, Modal, Input, InputNumber } from 'antd';
+import { Tooltip, Modal, InputNumber } from 'antd';
 import ReactTimeAgo from 'react-time-ago';
 import { useCallback, useMemo, useState } from 'react';
 import { MenuIcon, Pause, Play } from '../Icons';
@@ -264,7 +264,8 @@ const Actions = ({ song }: ComponentProps) => {
 
 const Time = ({ song }: ComponentProps) => {
   const [open, setOpen] = useState(false);
-  const [start, setStart] = useState('');
+  const [startMinutes, setStartMinutes] = useState<number | null>(null);
+  const [startSeconds, setStartSeconds] = useState<number | null>(null);
   const [seconds, setSeconds] = useState<number | null>(null);
 
   return (
@@ -284,16 +285,35 @@ const Time = ({ song }: ComponentProps) => {
         onCancel={() => setOpen(false)}
         title='設定播放時間'
       >
-        <Input
-          placeholder='開始時間'
-          value={start}
-          onChange={(e) => setStart(e.target.value)}
+        <div
+          style={{ display: 'flex', alignItems: 'center', gap: 8 }}
           className='mb-2'
-        />
+        >
+          <InputNumber
+            placeholder='分'
+            value={startMinutes ?? undefined}
+            onChange={(value) =>
+              setStartMinutes(typeof value === 'number' ? value : null)
+            }
+            min={0}
+          />
+          <span>:</span>
+          <InputNumber
+            placeholder='秒'
+            value={startSeconds ?? undefined}
+            onChange={(value) =>
+              setStartSeconds(typeof value === 'number' ? value : null)
+            }
+            min={0}
+            max={59}
+          />
+        </div>
         <InputNumber
-          placeholder='秒數'
+          placeholder='播放秒數'
           value={seconds ?? undefined}
-          onChange={(value) => setSeconds(typeof value === 'number' ? value : null)}
+          onChange={(value) =>
+            setSeconds(typeof value === 'number' ? value : null)
+          }
           style={{ width: '100%' }}
         />
       </Modal>

--- a/src/pages/Playlist/table/Song.tsx
+++ b/src/pages/Playlist/table/Song.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 import { PlaylistItemWithSaved } from '../../../interfaces/playlists';
 import SongView, { SongViewComponents } from '../../../components/SongsTable/songView';
 import { msToTime } from '../../../utils';
-import { Modal, Input, InputNumber } from 'antd';
+import { Modal, InputNumber } from 'antd';
 import { FaGear } from 'react-icons/fa6';
 
 // Redux
@@ -24,7 +24,8 @@ export const Song = (props: SongProps) => {
   const playlist = useAppSelector((state) => state.playlist.playlist);
 
   const [open, setOpen] = useState(false);
-  const [start, setStart] = useState('');
+  const [startMinutes, setStartMinutes] = useState<number | null>(null);
+  const [startSeconds, setStartSeconds] = useState<number | null>(null);
   const [seconds, setSeconds] = useState<number | null>(null);
 
   const toggleLike = useCallback(() => {
@@ -82,14 +83,35 @@ export const Song = (props: SongProps) => {
                 onCancel={() => setOpen(false)}
                 title='設定播放時間'
               >
-                <Input
-                  placeholder='開始時間'
-                  value={start}
-                  onChange={(e) => setStart(e.target.value)}
+                <div
+                  style={{ display: 'flex', alignItems: 'center', gap: 8 }}
                   className='mb-2'
-                />
+                >
+                  <InputNumber
+                    placeholder='分'
+                    value={startMinutes ?? undefined}
+                    onChange={(value) =>
+                      setStartMinutes(
+                        typeof value === 'number' ? value : null
+                      )
+                    }
+                    min={0}
+                  />
+                  <span>:</span>
+                  <InputNumber
+                    placeholder='秒'
+                    value={startSeconds ?? undefined}
+                    onChange={(value) =>
+                      setStartSeconds(
+                        typeof value === 'number' ? value : null
+                      )
+                    }
+                    min={0}
+                    max={59}
+                  />
+                </div>
                 <InputNumber
-                  placeholder='秒數'
+                  placeholder='播放秒數'
                   value={seconds ?? undefined}
                   onChange={(value) =>
                     setSeconds(typeof value === 'number' ? value : null)


### PR DESCRIPTION
## Summary
- use separate minute and second inputs when setting song start time
- restore seconds input for playback duration
- label playback duration field as '播放秒數'

## Testing
- `CI=1 npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689ae5bf6e58832b9f918701a1fce376