### PR TITLE
feat: add Summertime timeout track

### DIFF
--- a/api/tracks/v2/track_timeout.ts
+++ b/api/tracks/v2/track_timeout.ts
@@ -6,6 +6,11 @@ function handler(req: IncomingMessage, res: ServerResponse) {
       name: '三天三夜',
       start: '0:00',
       duration: 50
+    },
+    {
+      name: 'Summertime',
+      start: '0:10',
+      duration: 50
     }
   ];
   res.statusCode = 200;

--- a/src/pages/Playlist/table/Song.tsx
+++ b/src/pages/Playlist/table/Song.tsx
@@ -3,7 +3,7 @@ import dayjs, { type Dayjs } from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { PlaylistItemWithSaved } from '../../../interfaces/playlists';
 import SongView, { SongViewComponents } from '../../../components/SongsTable/songView';
-import { msToTime } from '../../../utils';
+import { msToTime, timeToMs } from '../../../utils';
 import { Modal, InputNumber, TimePicker } from 'antd';
 import { FaGear } from 'react-icons/fa6';
 
@@ -82,7 +82,9 @@ export const Song = (props: SongProps) => {
         (props) => {
           const info = extendedTracks.get(props.song.name);
           const duration = info
-            ? msToTime(info.duration * 1000)
+            ? `${info.start}-${msToTime(
+                timeToMs(info.start) + info.duration * 1000,
+              )}`
             : msToTime(props.song.duration_ms);
           return (
             <>


### PR DESCRIPTION
## Summary
- add Summertime to timeout track list
- show start-end range for custom track durations in playlist table

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eca068190832ba2a4d7e0c05e8dde