### PR TITLE
fix: remove now option from start time input

### DIFF
--- a/src/pages/Playlist/table/Song.tsx
+++ b/src/pages/Playlist/table/Song.tsx
@@ -113,21 +113,21 @@ export const Song = (props: SongProps) => {
                 title='設定播放時間'
               >
                 <TimePicker
-                  className='mb-2'
+                  className='mb-2 w-full'
                   value={startTime}
                   onChange={(value) => setStartTime(value)}
                   format='mm:ss'
                   disabledTime={disabledTime}
-                  style={{ width: '100%' }}
+                  showNow={false}
                 />
                 <InputNumber
                   placeholder='播放秒數'
+                  className='w-full'
                   value={seconds ?? undefined}
                   onChange={(value) =>
                     setSeconds(typeof value === 'number' ? value : null)
                   }
                   max={remainingSeconds}
-                  style={{ width: '100%' }}
                 />
               </Modal>
             </>


### PR DESCRIPTION
## Summary
- hide the "Now" shortcut in the playback start time picker
- style playback start time and duration inputs for full-width layout

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ecf4e2148832ba897f40e94b47b08