### PR TITLE
style: enhance playback duration input appearance

### DIFF
--- a/src/components/SongsTable/songView.tsx
+++ b/src/components/SongsTable/songView.tsx
@@ -310,11 +310,11 @@ const Time = ({ song }: ComponentProps) => {
         </div>
         <InputNumber
           placeholder='播放秒數'
+          className='duration-input'
           value={seconds ?? undefined}
           onChange={(value) =>
             setSeconds(typeof value === 'number' ? value : null)
           }
-          style={{ width: '100%' }}
         />
       </Modal>
     </>

--- a/src/pages/Playlist/table/Song.tsx
+++ b/src/pages/Playlist/table/Song.tsx
@@ -122,7 +122,7 @@ export const Song = (props: SongProps) => {
                 />
                 <InputNumber
                   placeholder='播放秒數'
-                  className='w-full'
+                  className='duration-input'
                   value={seconds ?? undefined}
                   onChange={(value) =>
                     setSeconds(typeof value === 'number' ? value : null)

--- a/src/styles/form.scss
+++ b/src/styles/form.scss
@@ -137,3 +137,34 @@ textarea::placeholder {
     transform: scale(1);
   }
 }
+
+.duration-input {
+  &.ant-input-number {
+    background: hsla(0, 0%, 100%, 0.1);
+    border: 1px solid #333;
+    border-radius: 4px;
+    color: #fff;
+    font-family: inherit;
+    font-size: 14px;
+    height: 40px;
+    padding: 0 12px;
+    width: 100%;
+
+    &:hover,
+    &:focus-within {
+      background-color: #333;
+      border-color: #535353;
+      box-shadow: none;
+    }
+
+    input {
+      background: transparent;
+      border: 0;
+      color: #fff;
+
+      &::placeholder {
+        color: #747474;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- style playback duration inputs for clearer visuals
- apply unified styling to playback duration fields

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed8594ffc832b8352ef52853de5c5