### PR TITLE
feat: Apply dark theme to time settings UI

### DIFF
--- a/src/pages/Playlist/table/TrackTimeSettings.tsx
+++ b/src/pages/Playlist/table/TrackTimeSettings.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import dayjs, { type Dayjs } from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
-import { Modal, InputNumber, TimePicker } from 'antd';
+import { ConfigProvider, Modal, InputNumber, TimePicker, theme } from 'antd';
 import { FaGear } from 'react-icons/fa6';
 import { msToTime, timeToMs } from '../../../utils';
 import { type Track } from '../../../interfaces/track';
@@ -70,34 +70,36 @@ export const TrackTimeSettings = (props: TrackTimeSettingsProps) => {
           <FaGear />
         </button>
       </p>
-      <Modal
-        destroyOnClose
-        className="track-time-settings-modal"
-        open={open}
-        onOk={() => setOpen(false)}
-        onCancel={() => setOpen(false)}
-        title='設定播放時間'
-      >
-        <TimePicker
-          className='mb-2 w-full track-time-picker'
-          value={startTime}
-          onChange={(value) => setStartTime(value)}
-          format='mm:ss'
-          disabledTime={disabledTime}
-          showNow={false}
-          inputReadOnly
-        />
-        <InputNumber
-          placeholder='播放秒數'
-          className='duration-input'
-          value={seconds ?? undefined}
-          onChange={(value) =>
-            setSeconds(typeof value === 'number' ? value : null)
-          }
-          max={remainingSeconds}
-          step="0.1"
-        />
-      </Modal>
+      <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }}>
+        <Modal
+          destroyOnClose
+          className="track-time-settings-modal"
+          open={open}
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+          title='設定播放時間'
+        >
+          <TimePicker
+            className='mb-2 w-full track-time-picker'
+            value={startTime}
+            onChange={(value) => setStartTime(value)}
+            format='mm:ss'
+            disabledTime={disabledTime}
+            showNow={false}
+            inputReadOnly
+          />
+          <InputNumber
+            placeholder='播放秒數'
+            className='duration-input'
+            value={seconds ?? undefined}
+            onChange={(value) =>
+              setSeconds(typeof value === 'number' ? value : null)
+            }
+            max={remainingSeconds}
+            step="0.1"
+          />
+        </Modal>
+      </ConfigProvider>
     </>
   );
 };

--- a/src/styles/form.scss
+++ b/src/styles/form.scss
@@ -3,10 +3,10 @@
   textarea,
   .ant-picker,
   .ant-input-number {
-    background: hsla(0, 0%, 100%, 0.1) !important;
+    background: hsla(0, 0%, 100%, 0.1);
     border: 1px solid transparent;
     border-radius: 4px;
-    color: #fff !important;
+    color: #fff;
     font-family: inherit;
     font-size: 14px;
     height: 40px;
@@ -138,6 +138,17 @@ textarea::placeholder {
     opacity: 0.85;
     transform: scale(1);
   }
+}
+
+.track-time-settings-modal {
+  .ant-modal-title {
+    color: #fff;
+  }
+}
+
+.ant-picker-panel .ant-picker-ok-btn {
+  background-color: #000 !important;
+  color: #fff !important;
 }
 
 .duration-input {


### PR DESCRIPTION
This commit applies a consistent dark theme to the time settings UI, including the `TimePicker`, `InputNumber`, and the `TimePicker`'s popup panel.

This is achieved by wrapping the modal in a `ConfigProvider` with antd's `darkAlgorithm`. This ensures that all components within the modal and its popups are styled with a dark theme.

Some CSS overrides were also removed to allow the `ConfigProvider`'s theme to take precedence, ensuring a more consistent and robust dark theme implementation.