### PR TITLE
chore: Add logging to debug GET handler

### DIFF
--- a/api/tracks/v2/track_timeout.ts
+++ b/api/tracks/v2/track_timeout.ts
@@ -27,6 +27,8 @@ function handler(req: IncomingMessage, res: ServerResponse) {
           result: [, keys],
         } = await scanResponse.json();
 
+        console.log('Keys from SCAN:', keys);
+
         if (!keys || keys.length === 0) {
           res.statusCode = 200;
           res.setHeader('Content-Type', 'application/json');
@@ -52,6 +54,7 @@ function handler(req: IncomingMessage, res: ServerResponse) {
         }
 
         const tracksData = await mgetResponse.json();
+        console.log('Data from MGET:', tracksData);
         const tracks = tracksData.result
           .map((track) => (track ? JSON.parse(track) : null))
           .filter(Boolean);


### PR DESCRIPTION
This commit adds `console.log` statements to the GET handler in `/api/tracks/v2/track_timeout.ts`.

This logging is added to help debug an issue where data fetched from the KV store is not appearing on the frontend. It logs the keys returned from the `SCAN` command and the data returned from the `MGET` command.