### PR TITLE
fix: delay auto login until user initiates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ const SpotifyContainer: FC<{ children: any }> = memo(({ children }) => {
       initRefreshTokenTimer(dispatch);
       dispatch(authActions.fetchUser());
     } else {
-      dispatch(loginToSpotify(true));
+      dispatch(authActions.setRequesting({ requesting: false }));
     }
 
     return () => {


### PR DESCRIPTION
## Summary
- stop auto redirecting to Spotify login when no token is present

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a2dabbf3a0832bb4b9f3c3a3d34cc6